### PR TITLE
Fix macOS build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ if(POLICY CMP0083)
 endif()
 
 project(LIBJXL LANGUAGES C CXX)
+set(CMAKE_CXX_STANDARD 11)
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(

--- a/src/lib/jxl.cmake
+++ b/src/lib/jxl.cmake
@@ -190,6 +190,7 @@ target_include_directories(jxl_enc-obj PUBLIC
   ${PROJECT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   $<TARGET_PROPERTY:hwy,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:lcms2,INTERFACE_INCLUDE_DIRECTORIES>
 #  $<TARGET_PROPERTY:brotlicommon-static,INTERFACE_INCLUDE_DIRECTORIES>
 )
 target_compile_definitions(jxl_enc-obj PUBLIC


### PR DESCRIPTION
I noticed two issues when building the `ssimulacra2` executable on my macOS 12.6 machine via `./build_ssimulacra`:

```
[10/54] Building CXX object lib/CMakeFiles/jxl_dec-obj.dir/jxl/dec_external_image.cc.o
FAILED: lib/CMakeFiles/jxl_dec-obj.dir/jxl/dec_external_image.cc.o
[..]
/Users/dbl/src/github.com/cloudinary/ssimulacra2/src/lib/jxl/base/status.h:279:3: error: unknown type name 'constexpr'
```
Fixed by setting `CMAKE_CXX_STANDARD` (a7a6adb6a8129c5b37b51ef97b80b659c47e22ad).

```
[22/54] Building CXX object lib/CMakeFiles/jxl_enc-obj.dir/jxl/enc_color_management.cc.o
FAILED: lib/CMakeFiles/jxl_enc-obj.dir/jxl/enc_color_management.cc.o 
[..]
/Users/dbl/src/github.com/cloudinary/ssimulacra2/src/lib/jxl/enc_color_management.cc:39:10: fatal error: 'lcms2.h' file not found
#include "lcms2.h"
         ^~~~~~~~~
1 error generated.
```
Looks like the include dir for the lcms2 Homebrew package isn't added. Fixed with 4afe13580e7fef313b4912594d6d23dabb702cdb.